### PR TITLE
Add predownload plugin

### DIFF
--- a/zypp/Fetcher.cc
+++ b/zypp/Fetcher.cc
@@ -534,8 +534,10 @@ namespace zypp
 
       // get cached file (by checksum) or provide from media
       Pathname tmpFile = locateInCache( resource, destDir_r );
-      if ( tmpFile.empty() )
-      {
+
+      if ( !tmpFile.empty() ) {
+        MIL << "Found in cache, verifying..." << endl;
+      } else {
         MIL << "Not found in cache, retrieving..." << endl;
         tmpFile = media_r.provideFile( resource, resource.optional() ? MediaSetAccess::PROVIDE_NON_INTERACTIVE : MediaSetAccess::PROVIDE_DEFAULT );
         releaseFileGuard.reset( new MediaSetAccess::ReleaseFileGuard( media_r, resource ) ); // release it when we leave the block

--- a/zypp/PluginExecutor.cc
+++ b/zypp/PluginExecutor.cc
@@ -101,6 +101,9 @@ namespace zypp
     const std::list<PluginScript> scripts() const
     { return _scripts; }
 
+    PluginScript first()
+    { return *_scripts.begin(); }
+
   private:
     /** Launch a plugin sending PLUGINSTART message. */
     void doLoad( const PathInfo & pi_r )
@@ -176,6 +179,9 @@ namespace zypp
 
   void PluginExecutor::send( const PluginFrame & frame_r )
   { _pimpl->send( frame_r ); }
+
+  PluginScript PluginExecutor::first()
+  { return _pimpl->first(); }
 
   std::ostream & operator<<( std::ostream & str, const PluginExecutor & obj )
   { return str << obj._pimpl->scripts(); }

--- a/zypp/PluginExecutor.h
+++ b/zypp/PluginExecutor.h
@@ -61,6 +61,9 @@ namespace zypp
       /** Number of open plugins */
       size_t size() const;
 
+      /** First plugin */
+      PluginScript first();
+
     public:
       /** Find and launch plugins sending \c PLUGINBEGIN.
        *

--- a/zypp/PluginScript.cc
+++ b/zypp/PluginScript.cc
@@ -175,6 +175,8 @@ namespace zypp
 
       void send( const PluginFrame & frame_r ) const;
 
+      Progress progress() const;
+
       PluginFrame receive() const;
 
     private:
@@ -273,6 +275,23 @@ namespace zypp
     }
     return _lastReturn;
   }
+
+  PluginScript::Progress PluginScript::Impl::progress() const
+  {
+    const PluginFrame frame_r = PluginFrame( "PLUGIN_PROGRESS" );
+    PluginFrame resp;
+    Progress ret(-1,-1);
+    this->send( frame_r );
+    resp = this->receive();
+    if(resp.empty())
+      return ret;
+
+    ret.first = atoi( resp.getHeaderNT("PLUGIN_PROGRESS_CURRENT", "-1").c_str() );
+    ret.second = atoi( resp.getHeaderNT("PLUGIN_PROGRESS_MAX", "-1").c_str() );
+
+    return ret;
+  }
+  
 
   void PluginScript::Impl::send( const PluginFrame & frame_r ) const
   {
@@ -518,6 +537,9 @@ namespace zypp
 
   void PluginScript::send( const PluginFrame & frame_r ) const
   { _pimpl->send( frame_r ); }
+
+  PluginScript::Progress PluginScript::progress() const
+  { return _pimpl->progress(); }
 
   PluginFrame PluginScript::receive() const
   { return _pimpl->receive(); }

--- a/zypp/PluginScript.h
+++ b/zypp/PluginScript.h
@@ -66,6 +66,7 @@ namespace zypp
     public:
       /** Commandline arguments passed to a script on \ref open. */
       using Arguments = std::vector<std::string>;
+      using Progress = std::pair<int, int>;
 
       /** \c pid_t(-1) constant indicating no connection. */
       static const pid_t NotConnected;
@@ -171,6 +172,15 @@ namespace zypp
        *
        */
       void send( const PluginFrame & frame_r ) const;
+      
+      /** Send PLUGIN_PROGRESS frame and return /ref PluginScript::Progress
+       * \throw PluginScriptNotConnected
+       * \throw PluginScriptSendTimeout
+       * \throw PluginScriptDiedUnexpectedly (does not \ref close)
+       * \throw PluginScriptException on error
+       *
+       */
+      Progress progress() const;
 
       /** Receive a \ref PluginFrame.
        * \throw PluginScriptNotConnected

--- a/zypp/RepoInfo.cc
+++ b/zypp/RepoInfo.cc
@@ -338,6 +338,9 @@ namespace zypp
     void packagesPath( Pathname new_r )
     { _packagesPath = std::move( new_r ); }
 
+    void predownloadPath( Pathname new_r )
+    { _predownloadPath = std::move( new_r ); }
+
     bool usesAutoMetadataPaths() const
     { return str::hasSuffix( _metadataPath.asString(), "/%AUTO%" ); }
 
@@ -355,12 +358,18 @@ namespace zypp
       return _packagesPath;
     }
 
+    Pathname predownloadPath() const
+    {
+      return _predownloadPath;
+    }
+
     DefaultIntegral<unsigned,defaultPriority> priority;
     mutable bool emptybaseurls;
 
   private:
     Pathname _metadataPath;
     Pathname _packagesPath;
+    Pathname _predownloadPath;
 
     mutable RepoVariablesReplacedUrlList _baseUrls;
     mutable std::pair<FalseBool, std::set<std::string> > _keywords;
@@ -578,6 +587,9 @@ namespace zypp
   void RepoInfo::setPackagesPath( const Pathname &path )
   { _pimpl->packagesPath( path ); }
 
+  void RepoInfo::setPredownloadPath( const Pathname &path )
+  { _pimpl->predownloadPath( path ); }
+
   void RepoInfo::setKeepPackages( bool keep )
   { _pimpl->keeppackages = keep; }
 
@@ -595,6 +607,9 @@ namespace zypp
 
   Pathname RepoInfo::packagesPath() const
   { return _pimpl->packagesPath(); }
+
+  Pathname RepoInfo::predownloadPath() const
+  { return _pimpl->predownloadPath(); }
 
   bool RepoInfo::usesAutoMetadataPaths() const
   { return _pimpl->usesAutoMetadataPaths(); }
@@ -834,11 +849,12 @@ namespace zypp
     if ( ! indeterminate(_pimpl->keeppackages) )
       str << "- keeppackages: " << keepPackages() << std::endl;
 
-    strif( "- service     : ", service() );
-    strif( "- targetdistro: ", targetDistribution() );
-    strif( "- filePath:     ", filepath().asString() );
-    strif( "- metadataPath: ", metadataPath().asString() );
-    strif( "- packagesPath: ", packagesPath().asString() );
+    strif( "- service     :    ", service() );
+    strif( "- targetdistro:    ", targetDistribution() );
+    strif( "- filePath:        ", filepath().asString() );
+    strif( "- metadataPath:    ", metadataPath().asString() );
+    strif( "- packagesPath:    ", packagesPath().asString() );
+    strif( "- predownloadPath: ", predownloadPath().asString() );
 
     return str;
   }

--- a/zypp/RepoInfo.h
+++ b/zypp/RepoInfo.h
@@ -278,11 +278,21 @@ namespace zypp
        */
       Pathname packagesPath() const;
       /**
+       * \short Path where this repo packages are cached
+       */
+      Pathname predownloadPath() const;
+      /**
        * \short set the path where the local packages are stored
        *
        * \param path directory path
        */
       void setPackagesPath( const Pathname &path );
+      /**
+       * \short set the path where the packages may be stored by plugins
+       *
+       * \param path directory path
+       */
+      void setPredownloadPath( const Pathname &path );
 
 
       /** \name Repository gpgchecks

--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -187,6 +187,7 @@ namespace zypp
     oinfo.setFilepath( updatedRepo.filepath() );
     oinfo.setMetadataPath( zyppng::rawcache_path_for_repoinfo( _pimpl->ngMgr().options(), updatedRepo ).unwrap() );
     oinfo.setPackagesPath( zyppng::packagescache_path_for_repoinfo( _pimpl->ngMgr().options(), updatedRepo ).unwrap() );
+    oinfo.setPredownloadPath( zyppng::predownloadcache_path_for_repoinfo( _pimpl->ngMgr().options(), updatedRepo ).unwrap() );
   }
 
   void RepoManager::addRepositories( const Url &url, const ProgressData::ReceiverFnc & progressrcv )
@@ -208,6 +209,7 @@ namespace zypp
     oinfo.setFilepath( updated.filepath());
     oinfo.setMetadataPath( zyppng::rawcache_path_for_repoinfo( _pimpl->ngMgr().options(), updated ).unwrap() );
     oinfo.setPackagesPath( zyppng::packagescache_path_for_repoinfo( _pimpl->ngMgr().options(), updated ).unwrap() );
+    oinfo.setPredownloadPath( zyppng::predownloadcache_path_for_repoinfo( _pimpl->ngMgr().options(), updated ).unwrap() );
   }
 
   RepoInfo RepoManager::getRepositoryInfo( const std::string &alias, const ProgressData::ReceiverFnc & progressrcv )

--- a/zypp/ng/repo/workflows/repomanagerwf.cc
+++ b/zypp/ng/repo/workflows/repomanagerwf.cc
@@ -1001,10 +1001,15 @@ namespace zyppng::RepoManagerWorkflow {
             const auto &pckCachePath = packagescache_path_for_repoinfo( options, *it ) ;
             if ( !pckCachePath ) return expected<void>::error(pckCachePath.error());
 
+            const auto &predownloadCachePath = predownloadcache_path_for_repoinfo( options, *it ) ;
+
             it->dumpAsIniOn(file);
             it->setFilepath(repofile);
             it->setMetadataPath( *rawCachePath );
             it->setPackagesPath( *pckCachePath );
+            if ( !predownloadCachePath->empty() )
+                it->setPredownloadPath( *predownloadCachePath );
+
             _repoMgrRef->reposManip().insert(*it);
 
             zypp::HistoryLog( _repoMgrRef->options().rootDir).addRepository(*it);

--- a/zypp/ng/repomanager.cc
+++ b/zypp/ng/repomanager.cc
@@ -593,6 +593,7 @@ namespace zyppng
       tosave.setFilepath(repofile);
       tosave.setMetadataPath( rawcache_path_for_repoinfo( _options, tosave ).unwrap() );
       tosave.setPackagesPath( packagescache_path_for_repoinfo( _options, tosave ).unwrap() );
+      tosave.setPredownloadPath( predownloadcache_path_for_repoinfo( _options, tosave ).unwrap() );
       reposManip().insert(tosave);
 
       // check for credentials in Urls
@@ -763,6 +764,7 @@ namespace zyppng
       newinfo.setFilepath(toedit.filepath());
       newinfo.setMetadataPath( rawcache_path_for_repoinfo( _options, newinfo ).unwrap() );
       newinfo.setPackagesPath( packagescache_path_for_repoinfo( _options, newinfo ).unwrap() );
+      newinfo.setPredownloadPath( predownloadcache_path_for_repoinfo( _options, newinfo ).unwrap() );
 
       ProgressObserver::increase( myProgress );
 
@@ -1406,6 +1408,7 @@ namespace zyppng
         repoInfo.setMetadataPath( rawcache_path_for_repoinfo(_options, repoInfo).unwrap() );
         // set the downloaded packages path for the repo
         repoInfo.setPackagesPath( packagescache_path_for_repoinfo(_options, repoInfo).unwrap() );
+        repoInfo.setPredownloadPath( predownloadcache_path_for_repoinfo(_options, repoInfo).unwrap() );
         // remember it
         _reposX.insert( repoInfo );	// direct access via _reposX in ctor! no reposManip.
 

--- a/zypp/ng/repomanager.h
+++ b/zypp/ng/repomanager.h
@@ -199,6 +199,16 @@ namespace zyppng {
   }
 
   /**
+     * \short Calculates the predownload cache path for a repository
+     */
+  inline expected<zypp::Pathname> predownloadcache_path_for_repoinfo( const RepoManagerOptions &opt, const RepoInfo &info )
+  {
+    using namespace zyppng::operators;
+    return assert_alias(info) |
+    and_then([&](){ return make_expected_success(isTmpRepo( info ) ? info.predownloadPath() : opt.repoPackagesCachePath.extend( std::string(".todo")) / info.escaped_alias()); });
+  }
+
+  /**
      * \short Calculates the solv cache path for a repository
      */
   inline expected<zypp::Pathname> solv_path_for_repoinfo( const RepoManagerOptions &opt, const RepoInfo &info )

--- a/zypp/repo/RepoProvideFile.cc
+++ b/zypp/repo/RepoProvideFile.cc
@@ -270,6 +270,12 @@ namespace zypp
       Fetcher fetcher;
       fetcher.addCachePath( repo_r.packagesPath() );
       MIL << "Added cache path " << repo_r.packagesPath() << endl;
+      if ( ! repo_r.predownloadPath().empty() ) {
+          fetcher.addCachePath( repo_r.predownloadPath() );
+          MIL << "Added predownload cache path " << repo_r.predownloadPath() << endl;
+      } else {
+          MIL << "NO predownload cache path " << repo_r.alias() << endl;
+      }
 
       // Test whether download destination is writable, if not
       // switch into the tmpspace (e.g. bnc#755239, download and

--- a/zypp/target/CommitPackageCache.cc
+++ b/zypp/target/CommitPackageCache.cc
@@ -146,6 +146,9 @@ namespace zypp
     ManagedFile CommitPackageCache::get( const PoolItem & citem_r )
     { return _pimpl->get( citem_r ); }
 
+    ManagedFile CommitPackageCache::get_from_cache( const PoolItem & citem_r )
+    { return _pimpl->get_from_cache( citem_r ); }
+
     bool CommitPackageCache::preloaded() const
     { return _pimpl->preloaded(); }
 

--- a/zypp/target/CommitPackageCache.h
+++ b/zypp/target/CommitPackageCache.h
@@ -84,6 +84,7 @@ namespace zypp
 
       /** Provide a package. */
       ManagedFile get( const PoolItem & citem_r );
+      ManagedFile get_from_cache( const PoolItem & citem_r );
       /** \overload */
       ManagedFile get( sat::Solvable citem_r )
       { return get( PoolItem(citem_r) ); }

--- a/zypp/target/CommitPackageCacheImpl.h
+++ b/zypp/target/CommitPackageCacheImpl.h
@@ -59,6 +59,11 @@ namespace zypp
         return sourceProvidePackage( citem_r );
       }
 
+      virtual ManagedFile get_from_cache( const PoolItem & citem_r )
+      {
+        return sourceProvideCachedPackage( citem_r );
+      }
+
       void setCommitList( std::vector<sat::Solvable> commitList_r )
       { _commitList = std::move(commitList_r); }
 

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1301,6 +1301,8 @@ namespace zypp
       MIL << "Target loaded: " << system.solvablesSize() << " resolvables" << endl;
     }
 
+    void predownloadPluginsHook( CommitPackageCache & packageCache, const ZYppCommitResult::TransactionStepList & steps );
+
     ///////////////////////////////////////////////////////////////////
     //
     // COMMIT
@@ -1464,6 +1466,9 @@ namespace zypp
         bool miss = false;
         if ( policy_r.downloadMode() != DownloadAsNeeded  )
         {
+
+          predownloadPluginsHook(packageCache, steps);
+
           // Preload the cache. Until now this means pre-loading all packages.
           // Once DownloadInHeaps is fully implemented, this will change and
           // we may actually have more than one heap.
@@ -3045,6 +3050,142 @@ namespace zypp
       repo::RepoMediaAccess access_r;
       repo::SrcPackageProvider prov( access_r );
       return prov.provideSrcPackage( srcPackage_r );
+    }
+
+
+    void predownloadPluginsHook( CommitPackageCache & packageCache, const ZYppCommitResult::TransactionStepList & steps )
+    {
+      PluginExecutor plugins;
+      plugins.load( ZConfig::instance().pluginsPath()/"predownload" );
+      if ( ! plugins )
+        return;
+      MIL << "TargetImpl::predownloadPluginsHook() start" << endl;
+
+      // first build items for download, skipping those which are already in the cache
+      ZYppCommitResult::TransactionStepList stepsNotCached;
+      for_( it, steps.begin(), steps.end() )
+      {
+        switch ( it->stepType() )
+        {
+          case sat::Transaction::TRANSACTION_INSTALL:
+          case sat::Transaction::TRANSACTION_MULTIINSTALL:
+          // proceed: only install actionas may require download.
+          break;
+
+          default:
+          // next: no download for or non-packages and delete actions.
+          continue;
+          break;
+        }
+
+        PoolItem pi( *it );
+        if ( pi->isKind<Package>() || pi->isKind<SrcPackage>() )
+        {
+          ManagedFile localfile;
+          localfile = packageCache.get_from_cache( pi );
+          if (!localfile->empty())
+            localfile.resetDispose(); // keep the package file in the cache
+          else {
+            stepsNotCached.push_back(*it);
+          }
+        }
+      }
+      using namespace std;
+      if (stepsNotCached.empty()) {
+        JobReport::info( "Nothing to download" );
+        return;
+      }
+      JobReport::info( "Preparing predownload plugins..." );
+
+      string message = ( ZConfig::instance().repoCachePath()/"packages.todo" ).asString();
+      plugins.send( PluginFrame( "PREDOWNLOAD_DEST", message ) );
+      if ( plugins.empty() ) {
+        JobReport::warning( "Predownload plugins have died" );
+        return;
+      }
+
+      // collect info about required downloads
+      map<string, Url> repoUrls; // repo alias => baseurl
+      map<string, list<pair<int, string> > > repoFiles; // repo alias => [ ( file_size, file_location ) ]
+      for_(it, stepsNotCached.begin(), stepsNotCached.end()) {
+        if ( sat::Solvable solv = it->satSolvable() ) {
+          Repository repo = solv.repository();
+          string alias = repo.alias();
+          Url url = repo.info().url();
+          if (!url.isValid())
+            continue;
+          PoolItem pi( solv );
+
+          Package::constPtr p = pi->asKind<Package>();
+          string loc = p->location().filename().asString();
+
+          if (loc.size() < 2)
+            continue;
+          // let's trim leading './'
+          if (loc[0] == '.' && loc[1] == '/')
+            loc = loc.substr(2);
+
+          int sz = p->location().downloadSize();
+          repoUrls[alias] = url;
+          repoFiles[alias].push_back(make_pair(sz, loc));
+        }
+      }
+
+      // send a message to plugin:
+      // baseurl file1 file2 .. fileN
+      for_(it, repoUrls.begin(), repoUrls.end()) {
+        message = it->first + string(" ") + it->second.asString();
+        list<pair<int, string> >& files = repoFiles[it->first];
+        if (files.empty())
+            continue;
+        files.sort();
+        // reverse loop because after sort() the bigger files are at the end, we want the download start with them
+        for_(i, files.rbegin(), files.rend()) {
+          message += " " + i->second;
+        }
+        message += " "; // make sure there is a delimiter after last package
+        plugins.send( PluginFrame( "PREDOWNLOAD_FROM_REPO", message ) );
+      }
+      if ( plugins.empty() ) {
+        JobReport::warning( "Predownload plugins have died" );
+        return;
+      }
+      // only the first survived plugin will be called for now
+      PluginScript plugin = plugins.first();
+      JobReport::info( "Starting predownload plugin..." );
+
+      plugin.send( PluginFrame( "PREDOWNLOAD_START" ) );
+      plugin.receive();
+      typedef PluginScript::Progress Progress;
+      Progress last(0,0);
+      bool allgood = 0;
+
+      Progress pr = plugin.progress();
+      while(1) {
+        if (pr.second < 1) {
+          JobReport::warning( "Predownload plugin have failed to report progress, continue without plugin" );
+          break;
+        }
+        JobReport::info( str::Format(_("Waiting predownload... Progress: %1%/%2%") ) % pr.first % pr.second );
+        last = pr;
+
+        if (pr.first < pr.second)
+          sleep(1);
+        else {
+          if (pr.first > 0)
+            allgood = 1;
+          break;
+        }
+        pr = plugin.progress();
+      }
+      const string & lastError = plugin.lastExecError();
+      if (!lastError.empty()) {
+        JobReport::warning( "Predownload plugin error: " + lastError );
+      } else if (allgood) {
+        JobReport::info( "Predownload plugin finished without errors" );
+      }
+
+      MIL << "TargetImpl::predownloadPluginsHook() end" << endl;
     }
     ////////////////////////////////////////////////////////////////
   } // namespace target


### PR DESCRIPTION
Purpose:
- get faster downloads utilizing concurrent downloads with `sypplite` utility
- let others experiment with custom implementation of download (e.g. to deal with their specific limitations)

Implementation Algorithm:
1. check if any plugin present
2. create list of Transaction Steps which require download
3. for each repository involved in future downloads: 
- build a string where first word is baseurl and the tail is list of files required for download from that repo.
- send the list to the plugins (command PREDOWNLOAD_FROM_REPO).
4. if any of plugins is still present: pick the first one and ask him to do actual download (command PREDOWNLOAD_START).
5. check plugin for progress every second (command PLUGIN_PROGRESS)
6. Continue normally - all packages are expected to be in the cache now.

Implementation details:
1. A new method progress() was added to PluginScript, which defines how plugins will report progress.
2. Support for concurrent download of metadata by the plugin might be added later.
3. The current implementation of the plugin [sypplite.sh](https://github.com/andrii-suse/sypper/blob/master/predownload/sypplite.sh)  will create `request files` for sypplite utility in `/var/cache/zypp/packages/`


Testing with prebuilt libzypp (Tumbleweed only so far):
```
zypper ar -f http://download.opensuse.org/repositories/home:andriinikitin:sypper/openSUSE_Tumbleweed home:andriinikitin:sypper
zypper --gpg-auto-import-keys  ref
run zypper -n in --from home:andriinikitin:sypper sypplite libzypp
cp /usr/share/sypper/predownload/sypplite.sh /usr/lib/zypp/plugins/predownload/
sudo mkdir /var/cache/zypp/packages.todo/
```

Testing custom build with local files  (assuming you build libzypp in ~/libzypp-build/):
```
sudo zypper in perl-Mojolicious perl-Config-IniFiles perl-IO-Socket-SSL util-linux-systemd
git clone https://github.com/andrii-suse/sypper/ sypper
sudo make -C sypper install
sudo mkdir /usr/lib/zypp/plugins/predownload/
sudo cp sypper/predownload/sypper.sh /usr/lib/zypp/plugins/predownload/
sudo mkdir /var/cache/zypp/packages.todo/
sudo LD_PRELOAD=~/libzypp-build/zypp/libzypp.so.1735.0.11 zypper -vn dup
```

Current experimented results for performance gain on 200 - 3000 packages is 40% - 200% 