### PR TITLE
Add predownload plugin

### DIFF
--- a/zypp/PluginExecutor.cc
+++ b/zypp/PluginExecutor.cc
@@ -101,6 +101,9 @@ namespace zypp
     const std::list<PluginScript> scripts() const
     { return _scripts; }
 
+    PluginScript first()
+    { return *_scripts.begin(); }
+
   private:
     /** Launch a plugin sending PLUGINSTART message. */
     void doLoad( const PathInfo & pi_r )
@@ -176,6 +179,9 @@ namespace zypp
 
   void PluginExecutor::send( const PluginFrame & frame_r )
   { _pimpl->send( frame_r ); }
+
+  PluginScript PluginExecutor::first()
+  { return _pimpl->first(); }
 
   std::ostream & operator<<( std::ostream & str, const PluginExecutor & obj )
   { return str << obj._pimpl->scripts(); }

--- a/zypp/PluginExecutor.h
+++ b/zypp/PluginExecutor.h
@@ -61,6 +61,9 @@ namespace zypp
       /** Number of open plugins */
       size_t size() const;
 
+      /** First plugin */
+      PluginScript first();
+
     public:
       /** Find and launch plugins sending \c PLUGINBEGIN.
        *

--- a/zypp/PluginScript.cc
+++ b/zypp/PluginScript.cc
@@ -175,6 +175,8 @@ namespace zypp
 
       void send( const PluginFrame & frame_r ) const;
 
+      Progress progress() const;
+
       PluginFrame receive() const;
 
     private:
@@ -273,6 +275,23 @@ namespace zypp
     }
     return _lastReturn;
   }
+
+  PluginScript::Progress PluginScript::Impl::progress() const
+  {
+    const PluginFrame frame_r = PluginFrame( "PLUGIN_PROGRESS" );
+    PluginFrame resp;
+    Progress ret(-1,-1);
+    this->send( frame_r );
+    resp = this->receive();
+    if(resp.empty())
+      return ret;
+
+    ret.first = atoi( resp.getHeaderNT("PLUGIN_PROGRESS_CURRENT", "-1").c_str() );
+    ret.second = atoi( resp.getHeaderNT("PLUGIN_PROGRESS_MAX", "-1").c_str() );
+
+    return ret;
+  }
+  
 
   void PluginScript::Impl::send( const PluginFrame & frame_r ) const
   {
@@ -518,6 +537,9 @@ namespace zypp
 
   void PluginScript::send( const PluginFrame & frame_r ) const
   { _pimpl->send( frame_r ); }
+
+  PluginScript::Progress PluginScript::progress() const
+  { return _pimpl->progress(); }
 
   PluginFrame PluginScript::receive() const
   { return _pimpl->receive(); }

--- a/zypp/PluginScript.h
+++ b/zypp/PluginScript.h
@@ -66,6 +66,7 @@ namespace zypp
     public:
       /** Commandline arguments passed to a script on \ref open. */
       using Arguments = std::vector<std::string>;
+      using Progress = std::pair<int, int>;
 
       /** \c pid_t(-1) constant indicating no connection. */
       static const pid_t NotConnected;
@@ -171,6 +172,15 @@ namespace zypp
        *
        */
       void send( const PluginFrame & frame_r ) const;
+      
+      /** Send PLUGIN_PROGRESS frame and return /ref PluginScript::Progress
+       * \throw PluginScriptNotConnected
+       * \throw PluginScriptSendTimeout
+       * \throw PluginScriptDiedUnexpectedly (does not \ref close)
+       * \throw PluginScriptException on error
+       *
+       */
+      Progress progress() const;
 
       /** Receive a \ref PluginFrame.
        * \throw PluginScriptNotConnected

--- a/zypp/target/CommitPackageCache.cc
+++ b/zypp/target/CommitPackageCache.cc
@@ -146,6 +146,9 @@ namespace zypp
     ManagedFile CommitPackageCache::get( const PoolItem & citem_r )
     { return _pimpl->get( citem_r ); }
 
+    ManagedFile CommitPackageCache::get_from_cache( const PoolItem & citem_r )
+    { return _pimpl->get_from_cache( citem_r ); }
+
     bool CommitPackageCache::preloaded() const
     { return _pimpl->preloaded(); }
 

--- a/zypp/target/CommitPackageCache.h
+++ b/zypp/target/CommitPackageCache.h
@@ -84,6 +84,7 @@ namespace zypp
 
       /** Provide a package. */
       ManagedFile get( const PoolItem & citem_r );
+      ManagedFile get_from_cache( const PoolItem & citem_r );
       /** \overload */
       ManagedFile get( sat::Solvable citem_r )
       { return get( PoolItem(citem_r) ); }

--- a/zypp/target/CommitPackageCacheImpl.h
+++ b/zypp/target/CommitPackageCacheImpl.h
@@ -59,6 +59,11 @@ namespace zypp
         return sourceProvidePackage( citem_r );
       }
 
+      virtual ManagedFile get_from_cache( const PoolItem & citem_r )
+      {
+        return sourceProvideCachedPackage( citem_r );
+      }
+
       void setCommitList( std::vector<sat::Solvable> commitList_r )
       { _commitList = std::move(commitList_r); }
 


### PR DESCRIPTION
Alternative implementation of #1 , instead of using dedicated `packages.todo` folder, this PR puts packages into regular cache, but adds prefix `.unverified` to the file name.
The Fetcher code is aware of such prefix and looks and strips it out if the verification jobs confirm that the file is good.